### PR TITLE
add swipe back

### DIFF
--- a/src/components/MovieLoader.tsx
+++ b/src/components/MovieLoader.tsx
@@ -7,7 +7,6 @@ import Animated, {
 	withRepeat,
 	withSequence,
 	withDelay,
-	Easing,
 	interpolate,
 	cancelAnimation
 } from "react-native-reanimated";
@@ -49,10 +48,7 @@ function SkeletonCard({
 		shimmer.value = withDelay(
 			delay,
 			withRepeat(
-				withTiming(1, {
-					duration: 1600,
-					easing: Easing.inOut(Easing.sine)
-				}),
+				withTiming(1, { duration: 1600 }),
 				-1,
 				true
 			)
@@ -61,14 +57,8 @@ function SkeletonCard({
 			delay,
 			withRepeat(
 				withSequence(
-					withTiming(1, {
-						duration: 900,
-						easing: Easing.inOut(Easing.ease)
-					}),
-					withTiming(0, {
-						duration: 900,
-						easing: Easing.inOut(Easing.ease)
-					})
+					withTiming(1, { duration: 900 }),
+					withTiming(0, { duration: 900 })
 				),
 				-1,
 				false
@@ -140,14 +130,8 @@ function LoadingDot({ index }: { index: number }) {
 			index * 180,
 			withRepeat(
 				withSequence(
-					withTiming(1, {
-						duration: 400,
-						easing: Easing.out(Easing.ease)
-					}),
-					withTiming(0, {
-						duration: 400,
-						easing: Easing.in(Easing.ease)
-					}),
+					withTiming(1, { duration: 400 }),
+					withTiming(0, { duration: 400 }),
 					withDelay(300, withTiming(0, { duration: 0 }))
 				),
 				-1,
@@ -183,7 +167,7 @@ export default function MovieLoader() {
 	useEffect(() => {
 		titleOpacity.value = withDelay(
 			200,
-			withTiming(1, { duration: 600, easing: Easing.out(Easing.ease) })
+			withTiming(1, { duration: 600 })
 		);
 		return () => cancelAnimation(titleOpacity);
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/SwipeCard.tsx
+++ b/src/components/SwipeCard.tsx
@@ -1,13 +1,12 @@
 import React, { FC, memo, useEffect } from "react";
-import { Text, Dimensions, Image } from "react-native";
+import { Text, View, Dimensions, Image } from "react-native";
 import Animated, {
-	Easing,
 	Extrapolation,
 	interpolate,
 	SharedValue,
 	useAnimatedStyle,
 	useSharedValue,
-	withSpring
+	withTiming
 } from "react-native-reanimated";
 import styles from "../styles/SwipeCardStyle";
 
@@ -56,16 +55,10 @@ const SwipeCard: FC<SwipeCardViewProps> = ({
 
 	useEffect(() => {
 		const targetScale = isTopCard ? 1 : isSecondCard ? 0.95 : 0.9;
-		cardScale.value = withSpring(targetScale, {
-			duration: 300,
-			easing: Easing.out(Easing.quad)
-		});
+		cardScale.value = withTiming(targetScale, { duration: 300 });
 
 		const targetOpacity = isTopCard ? 1 : isSecondCard ? 0.85 : 0.7;
-		cardOpacity.value = withSpring(targetOpacity, {
-			duration: 300,
-			easing: Easing.out(Easing.quad)
-		});
+		cardOpacity.value = withTiming(targetOpacity, { duration: 300 });
 	}, [index, isTopCard, isSecondCard, cardScale, cardOpacity]);
 
 	const animationStyle = useAnimatedStyle(() => {
@@ -139,11 +132,15 @@ const SwipeCard: FC<SwipeCardViewProps> = ({
 				{ height: SCREEN_HEIGHT * 0.62 }
 			]}
 			{...panHandlers}>
-			<Image
-				source={{ uri: posterUri }}
-				style={styles.posterImage}
-				resizeMode="cover"
-			/>
+			{posterUri != null ? (
+				<Image
+					source={{ uri: posterUri }}
+					style={styles.posterImage}
+					resizeMode="cover"
+				/>
+			) : (
+				<View style={[styles.posterImage, { backgroundColor: "#13396A" }]} />
+			)}
 
 			{isTopCard && (
 				<>

--- a/src/screens/SwipeScreen.tsx
+++ b/src/screens/SwipeScreen.tsx
@@ -20,7 +20,7 @@ import {
 	withTiming
 } from "react-native-reanimated";
 import { useRouter } from "expo-router";
-import { fetchMovies } from "../services/SwipeService";
+import { fetchMovies, postSwipe, checkBackendHealth } from "../services/SwipeService";
 import SwipeCard, { Movie } from "../components/SwipeCard";
 import styles from "../styles/SwipeStyle";
 import { Ionicons } from "@expo/vector-icons";
@@ -29,6 +29,7 @@ import MovieLoader from "../components/MovieLoader";
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
 const SWIPE_THRESHOLD = SCREEN_WIDTH * 0.25;
 const SWIPE_OUT_DURATION = 250;
+const PREFETCH_THRESHOLD = 10;
 
 type SwipeDirection = "left" | "right" | "up";
 
@@ -53,6 +54,8 @@ export default function SwipeScreen() {
 	const moviesRef = useRef<Movie[]>([]);
 	const tapStartTime = useRef(0);
 	const isAnimatingRef = useRef(false);
+	const isFetchingMoreRef = useRef(false);
+	const seenMovieIdsRef = useRef<Set<number>>(new Set());
 
 	useEffect(() => {
 		currentIndexRef.current = currentIndex;
@@ -63,9 +66,36 @@ export default function SwipeScreen() {
 	}, [movies]);
 
 	useEffect(() => {
+		const remaining = movies.length - currentIndex;
+		if (remaining > PREFETCH_THRESHOLD || movies.length === 0 || isFetchingMoreRef.current) return;
+
+		isFetchingMoreRef.current = true;
+		fetchMovies().then((newMovies) => {
+			const fresh = newMovies.filter((m) => !seenMovieIdsRef.current.has(m.id));
+			fresh.forEach((m) => seenMovieIdsRef.current.add(m.id));
+			if (fresh.length > 0) {
+				setMovies((prev) => [...prev, ...fresh]);
+			}
+			isFetchingMoreRef.current = false;
+		}).catch(() => {
+			isFetchingMoreRef.current = false;
+		});
+	}, [currentIndex, movies.length]);
+
+	useEffect(() => {
 		const load = async () => {
+			if (__DEV__) {
+				const health = await checkBackendHealth();
+				if (!health.ok) {
+					console.warn("[SwipeScreen] Backend inaccessible →", health.error ?? "pas de /health");
+				} else {
+					console.log("[SwipeScreen] Backend OK");
+				}
+			}
+
 			try {
 				const res = await fetchMovies();
+				res.forEach((m) => seenMovieIdsRef.current.add(m.id));
 				setMovies(res);
 			} catch (err) {
 				console.error("Erreur lors du chargement des films :", err);
@@ -88,12 +118,16 @@ export default function SwipeScreen() {
 			const movie = moviesRef.current[currentIndexRef.current];
 			if (!movie) return;
 
+			const apiDirection =
+				direction === "right" ? "like" : direction === "left" ? "dislike" : "skip";
+			postSwipe(movie.id, apiDirection);
+
 			if (direction === "right") setLikedCount((n) => n + 1);
 			else if (direction === "left") setDislikedCount((n) => n + 1);
 			else setSkippedCount((n) => n + 1);
 
 			setCurrentIndex((prev) => prev + 1);
-			nextCardScale.value = withSpring(0.95, { duration: 400 });
+			nextCardScale.value = withTiming(0.95, { duration: 400 });
 			isAnimatingRef.current = false;
 			setIsAnimating(false);
 		},
@@ -132,7 +166,7 @@ export default function SwipeScreen() {
 	const resetPosition = useCallback(() => {
 		translateX.value = withSpring(0, { damping: 15 });
 		translateY.value = withSpring(0, { damping: 15 });
-		nextCardScale.value = withSpring(0.95, { duration: 300 });
+		nextCardScale.value = withTiming(0.95, { duration: 300 });
 	}, [nextCardScale, translateX, translateY]);
 
 	const panResponder = useRef(

--- a/src/services/SwipeService.ts
+++ b/src/services/SwipeService.ts
@@ -1,5 +1,14 @@
 import { ApiHelper } from "@/src/utils/axios";
 
+export const checkBackendHealth = async (): Promise<{ ok: boolean; error?: string }> => {
+	try {
+		const res = await ApiHelper.get("/health");
+		return { ok: res.success };
+	} catch (e: any) {
+		return { ok: false, error: e?.message ?? "unreachable" };
+	}
+};
+
 export type Movie = {
 	id: number; // ou string, selon ta base
 	title: string;
@@ -7,17 +16,44 @@ export type Movie = {
 	// Ajoute d'autres propriétés si besoin
 };
 
+export type ApiSwipeDirection = "like" | "dislike" | "skip";
+
+export const postSwipe = async (
+	movieId: number,
+	direction: ApiSwipeDirection
+): Promise<void> => {
+	try {
+		await ApiHelper.post("/swipes", { movie_id: movieId, direction });
+	} catch (error: any) {
+		if (__DEV__) console.error("Erreur postSwipe :", error);
+	}
+};
+
 export const fetchMovies = async (count: number = 50): Promise<Movie[]> => {
 	try {
 		const response = await ApiHelper.get(`/movies/random?count=${count}`);
 
-		if (!Array.isArray(response.data)) {
-			throw new Error("Données de films invalides");
+		if (!response.success) {
+			if (__DEV__) console.warn("fetchMovies: réponse backend KO →", response.data);
+			return [];
 		}
 
-		return response.data as Movie[];
+		if (!Array.isArray(response.data)) {
+			if (__DEV__) console.warn("fetchMovies: format inattendu →", response.data);
+			return [];
+		}
+
+		const valid = (response.data as any[]).filter(
+			(m) => typeof m.id === "number" && typeof m.title === "string"
+		);
+
+		if (__DEV__ && valid.length !== response.data.length) {
+			console.warn(`fetchMovies: ${response.data.length - valid.length} film(s) ignorés (données manquantes)`);
+		}
+
+		return valid as Movie[];
 	} catch (error: any) {
 		if (__DEV__) console.error("Erreur fetchMovies :", error);
-		return []; // retourne un tableau vide en cas d'erreur
+		return [];
 	}
 };


### PR DESCRIPTION
- Fixed silent native crash (Fabric/RN 0.83): Image with uri: null → conditional rendering
  - Fixed Reanimated 4 crash: Easing functions not serializable as worklets → removed from all withTiming calls                                                                                                
  - Fixed Axios crash: unsafe access to error.response.data.detail → optional chaining with fallback
  - POST /swipes called on every swipe (fire-and-forget)                                                                                                                                                       
  - Automatic background fetch of new movies when fewer than 10 cards remain (smooth infinite scroll, no duplicates)  